### PR TITLE
Add documented `backend.main` entrypoint, refresh frontend UI, and update package scripts/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This repository contains a prototype platform for running machine-learning exper
 ## Project layout
 
 ```
-backend/                   Entrypoint for the FastAPI app
 computational_litho_ai/    Main Python package with API routes, ML code and utilities
 └── api/                   FastAPI routes and service logic
+└── backend/               Compatibility entrypoint for `uvicorn backend.main:app`
 └── agents/                Example LangChain tools and QA scripts
 └── frontend/              Vite/React interface
 └── ml/                    Simple PyTorch and scikit‑learn models
@@ -26,15 +26,17 @@ httpx/, multipart/, pandas/ Minimal stubs used for testing without real dependen
 ## Getting started
 
 1. Install the required dependencies (FastAPI, PyTorch, scikit‑learn, etc.).
-2. Launch the backend:
+2. Launch the backend from inside the `computational_litho_ai` directory:
    ```bash
+   cd computational_litho_ai
    uvicorn backend.main:app --reload
    ```
-3. Start the frontend development server inside `computational_litho_ai/frontend`:
+3. Start the frontend development server from the `computational_litho_ai` directory:
    ```bash
    npm install
    npm run dev
    ```
+   The root `dev` script installs frontend dependencies and delegates to the Vite app in `computational_litho_ai/frontend`.
 4. Run the tests (requires all optional dependencies):
    ```bash
    pytest

--- a/computational_litho_ai/backend/__init__.py
+++ b/computational_litho_ai/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility package for the documented backend import path."""

--- a/computational_litho_ai/backend/main.py
+++ b/computational_litho_ai/backend/main.py
@@ -1,0 +1,10 @@
+"""Compatibility entrypoint for running the FastAPI app as ``backend.main``.
+
+The application implementation lives in :mod:`api.main`. This module keeps the
+README command ``uvicorn backend.main:app --reload`` working when developers run
+it from the ``computational_litho_ai`` directory.
+"""
+
+from api.main import app
+
+__all__ = ["app"]

--- a/computational_litho_ai/frontend/src/App.jsx
+++ b/computational_litho_ai/frontend/src/App.jsx
@@ -3,42 +3,81 @@ import UploadCSV from './components/UploadCSV';
 import InferenceForm from './components/InferenceForm';
 import ImageInference from './components/ImageInference';
 import AutoEncoderInfer from './components/AutoEncoderInfer';
-import ChatAssistant from './components/ChatAssistant'; // ✅ Import Chat Assistant
+import ChatAssistant from './components/ChatAssistant';
+
+const features = [
+  {
+    title: 'CSV Pipeline',
+    description: 'Upload process data and validate the backend connection before advanced inference.',
+  },
+  {
+    title: 'Model Inference',
+    description: 'Run prediction and visualize tabular outputs with quick export support.',
+  },
+  {
+    title: 'Image + AutoEncoder',
+    description: 'Classify, reconstruct, and inspect image-based responses from trained models.',
+  },
+  {
+    title: 'AI Assistant',
+    description: 'Use tool mode, doc QA, PDF ingestion, and tensor-session analysis in one place.',
+  },
+];
 
 function App() {
-  const [serverStatus, setServerStatus] = useState("⏳ Checking server...");
+  const [serverStatus, setServerStatus] = useState('⏳ Checking server...');
 
   useEffect(() => {
-    fetch("http://127.0.0.1:8000/health/ping")
+    fetch('http://127.0.0.1:8000/health/ping')
       .then((res) => res.json())
       .then((data) => {
-        if (data.status === "ok") {
-          setServerStatus("✅ Server is up");
+        if (data.status === 'ok') {
+          setServerStatus('✅ Server is up');
         } else {
-          setServerStatus("❌ Server down");
+          setServerStatus('❌ Server down');
         }
       })
       .catch(() => {
-        setServerStatus("❌ Server down");
+        setServerStatus('❌ Server down');
       });
   }, []);
 
   return (
-    <div className="p-8">
-      <div className="max-w-4xl mx-auto bg-white p-8 rounded-lg shadow-lg">
-        <h1 className="text-4xl font-extrabold mb-2 text-blue-700 text-center">🧠 Computational Lithography AI</h1>
-        <p className="mb-6 text-sm text-gray-600 text-center">{serverStatus}</p>
-        
-        {/* Main features */}
-        <UploadCSV />
-        <InferenceForm />
-        <ImageInference />
-        <AutoEncoderInfer />
+    <div className="min-h-screen px-4 py-8 sm:px-6 lg:px-10">
+      <div className="mx-auto max-w-6xl">
+        <header className="rounded-2xl border border-blue-100 bg-white/90 p-6 shadow-lg backdrop-blur sm:p-8">
+          <p className="mb-3 inline-flex rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-blue-700">
+            Computational Lithography Platform
+          </p>
+          <h1 className="text-3xl font-black leading-tight text-slate-900 sm:text-4xl">
+            🧠 Computational Lithography AI
+          </h1>
+          <p className="mt-3 max-w-3xl text-sm text-slate-600 sm:text-base">
+            A unified workspace for dataset upload, production inference, image reconstruction workflows,
+            and assistant-powered analysis.
+          </p>
+          <p className="mt-4 text-sm font-medium text-slate-700">{serverStatus}</p>
+        </header>
 
-        {/* ✅ Chat Assistant Section */}
-        <div className="mt-10">
+        <section className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {features.map((feature) => (
+            <article
+              key={feature.title}
+              className="rounded-xl border border-slate-200/70 bg-white/90 p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
+            >
+              <h2 className="text-sm font-bold text-slate-800">{feature.title}</h2>
+              <p className="mt-1 text-xs leading-5 text-slate-600">{feature.description}</p>
+            </article>
+          ))}
+        </section>
+
+        <main className="mt-8 space-y-6">
+          <UploadCSV />
+          <InferenceForm />
+          <ImageInference />
+          <AutoEncoderInfer />
           <ChatAssistant />
-        </div>
+        </main>
       </div>
     </div>
   );

--- a/computational_litho_ai/frontend/src/components/UploadCSV.jsx
+++ b/computational_litho_ai/frontend/src/components/UploadCSV.jsx
@@ -5,23 +5,47 @@ function UploadCSV() {
   const [file, setFile] = useState(null);
 
   const handleUpload = async () => {
+    if (!file) {
+      alert('Please select a CSV file first.');
+      return;
+    }
+
     const formData = new FormData();
     formData.append('file', file);
 
     try {
-      const response = await axios.post("http://127.0.0.1:8000/upload/", formData);
-      alert("✅ File uploaded successfully!");
+      await axios.post('http://127.0.0.1:8000/upload/', formData);
+      alert('✅ File uploaded successfully!');
     } catch (err) {
-      alert("❌ Upload failed");
+      alert('❌ Upload failed');
       console.error(err);
     }
   };
 
   return (
-    <div className="p-4">
-      <input type="file" accept=".csv" onChange={(e) => setFile(e.target.files[0])} />
-      <button onClick={handleUpload} className="ml-2 bg-blue-500 text-white px-3 py-1 rounded">Upload</button>
-    </div>
+    <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
+      <h2 className="text-xl font-semibold text-slate-800">📁 CSV Upload</h2>
+      <p className="mt-1 text-sm text-slate-600">
+        Upload production/process CSV files to prepare data for downstream predictions.
+      </p>
+
+      <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center">
+        <input
+          type="file"
+          accept=".csv"
+          onChange={(e) => setFile(e.target.files[0])}
+          className="w-full rounded-lg border border-slate-300 bg-slate-50 px-3 py-2 text-sm text-slate-700 file:mr-3 file:rounded-md file:border-0 file:bg-blue-600 file:px-3 file:py-2 file:text-sm file:font-medium file:text-white hover:file:bg-blue-700"
+        />
+        <button
+          onClick={handleUpload}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700"
+        >
+          Upload CSV
+        </button>
+      </div>
+
+      {file && <p className="mt-3 text-xs text-slate-500">Selected file: {file.name}</p>}
+    </section>
   );
 }
 

--- a/computational_litho_ai/frontend/src/index.css
+++ b/computational_litho_ai/frontend/src/index.css
@@ -2,7 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  color-scheme: light;
+}
+
 body {
-  @apply bg-gradient-to-br from-gray-100 to-blue-50 min-h-screen;
-  font-family: ui-sans-serif, system-ui, sans-serif;
+  @apply min-h-screen bg-gradient-to-br from-slate-100 via-blue-50 to-indigo-100 text-slate-900;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+}
+
+* {
+  @apply border-slate-200;
 }

--- a/computational_litho_ai/package.json
+++ b/computational_litho_ai/package.json
@@ -1,4 +1,13 @@
 {
+  "name": "computational_litho_ai",
+  "private": true,
+  "scripts": {
+    "predev": "npm --prefix frontend install",
+    "dev": "npm --prefix frontend run dev",
+    "prebuild": "npm --prefix frontend install",
+    "build": "npm --prefix frontend run build",
+    "preview": "npm --prefix frontend run preview"
+  },
   "dependencies": {
     "recharts": "^2.15.3"
   }

--- a/computational_litho_ai/tests/api/test_routes.py
+++ b/computational_litho_ai/tests/api/test_routes.py
@@ -1,9 +1,19 @@
+import importlib
+
+
 def test_read_root(client):
     response = client.get("/")
     assert response.status_code == 200
     assert "message" in response.json()
 
+
 def test_health_check(client):
     response = client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+def test_documented_backend_entrypoint_imports_app():
+    backend_main = importlib.import_module("backend.main")
+    api_main = importlib.import_module("api.main")
+    assert backend_main.app is api_main.app


### PR DESCRIPTION
### Motivation
- Restore and document the compatibility entrypoint so the README command `uvicorn backend.main:app --reload` works when running from the `computational_litho_ai` directory. 
- Modernize the frontend layout and components for a clearer UX and consistent Tailwind styling. 
- Provide convenient NPM scripts at the repository root to run the frontend from the package root. 
- Add a test that validates the documented backend import path remains working.

### Description
- Added a compatibility backend package with `computational_litho_ai/backend/__init__.py` and `computational_litho_ai/backend/main.py` that re-exports the FastAPI `app` from `api.main` so `backend.main:app` resolves as documented. 
- Updated `README.md` to instruct running the backend from inside the `computational_litho_ai` directory and to reference the compatibility entrypoint. 
- Refactored the frontend `App.jsx` for a refreshed layout, introduced a `features` summary, improved server-status handling, and integrated `ChatAssistant` into the new layout. 
- Improved `UploadCSV.jsx` with client-side validation, improved markup and Tailwind styling, and clearer file selection feedback. 
- Enhanced styles in `frontend/src/index.css` (color scheme, font stack, background gradients and global border utility). 
- Added root-level `computational_litho_ai/package.json` scripts (`predev`, `dev`, `prebuild`, `build`, `preview`) so the frontend can be started from the package root via `npm run dev`. 
- Added a pytest in `tests/api/test_routes.py` called `test_documented_backend_entrypoint_imports_app` that imports `backend.main` and asserts it exposes the same `app` as `api.main`.

### Testing
- Ran the test suite with `pytest` and all tests completed successfully. 
- Verified `test_documented_backend_entrypoint_imports_app` imports `backend.main` and asserts `backend_main.app is api_main.app` passing in the CI/python test environment. 
- No automated frontend build tests were added; the new NPM scripts are declarative and can be exercised with `npm run dev` and `npm run build` locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da43ec5404832eaf0899c5220cda54)